### PR TITLE
support command mcp servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Example:
   "personality": "an open source AI chatbot named Ollamarama, powered by Ollama.",
   "mcp_servers": {
     "playwright": "http://localhost:8931/mcp",
-    "notes": {"command": "python", "args": ["notes_server.py"]}
+    "notes": {"command": "python", "args": ["notes_server.py"]},
+    "browser": {"command": "npx -y @modelcontext/browser"}
   }
 }
 ```
@@ -108,7 +109,8 @@ Field reference:
 - `prompt`: Two-element array `[prefix, suffix]` used to build a persona system prompt (prefix + personality + suffix).
 - `personality`: Default personality string used at startup. Use `/stock` to clear or `/persona` to change during a session.
 - `mcp_servers`: Optional map of server names to MCP server definitions. Each value may be a URL string or an object with a
-  `command` and optional `args` to launch a server via stdio. When present, tools are auto-discovered at startup.
+  `command` and optional `args` to launch a server via stdio. If `args` is omitted and the `command` string contains
+  spaces, it is automatically split into the executable and its arguments. When present, tools are auto-discovered at startup.
 
 Note: If no MCP servers are reachable, Ollamarama falls back to a bundled tool schema at `ollamarama/tools/schema.json`. If neither is available, tool calling is disabled automatically.
 
@@ -157,7 +159,8 @@ Ollamarama can call tools in the middle of a conversation. This is useful for ac
   3. If no schema is available, tool calling is disabled.
 
 Example MCP setup:
-1. Add your MCP server under `mcp_servers` in `config.json`. Each entry can be a URL or a `{ "command": ..., "args": [...] }` spec.
+1. Add your MCP server under `mcp_servers` in `config.json`. Each entry can be a URL or a `{ "command": ..., "args": [...] }`
+   spec. If the `command` string already includes arguments, `args` may be omitted and will be split automatically.
 2. Start `ollamarama`. Remote servers are connected to and command-based servers are launched automatically. Tools will be
    discovered without extra steps.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Example:
   ],
   "personality": "an open source AI chatbot named Ollamarama, powered by Ollama.",
   "mcp_servers": {
-    "playwright": "http://localhost:8931/mcp"
+    "playwright": "http://localhost:8931/mcp",
+    "notes": {"command": "python", "args": ["notes_server.py"]}
   }
 }
 ```
@@ -106,7 +107,8 @@ Field reference:
 - `default_model`: Key from `models` to select on startup.
 - `prompt`: Two-element array `[prefix, suffix]` used to build a persona system prompt (prefix + personality + suffix).
 - `personality`: Default personality string used at startup. Use `/stock` to clear or `/persona` to change during a session.
-- `mcp_servers`: Optional map of server names to MCP server URLs. When present, tools are auto-discovered at startup.
+- `mcp_servers`: Optional map of server names to MCP server definitions. Each value may be a URL string or an object with a
+  `command` and optional `args` to launch a server via stdio. When present, tools are auto-discovered at startup.
 
 Note: If no MCP servers are reachable, Ollamarama falls back to a bundled tool schema at `ollamarama/tools/schema.json`. If neither is available, tool calling is disabled automatically.
 
@@ -149,14 +151,15 @@ Ollamarama can call tools in the middle of a conversation. This is useful for ac
 
 - Enable/disable at runtime: `/tools`
 - On startup:
-  1. If `mcp_servers` are configured, Ollamarama connects to each via `fastmcp` and auto-discovers their tool schemas.
+  1. If `mcp_servers` are configured, Ollamarama connects to remote URLs or launches command-based servers via `fastmcp` and
+     auto-discovers their tool schemas.
   2. If discovery fails or no MCP servers are configured, it attempts to load a bundled schema from `ollamarama/tools/schema.json`.
   3. If no schema is available, tool calling is disabled.
 
 Example MCP setup:
-1. Start your MCP server (separately) and note its URL (e.g., `http://localhost:8931/mcp`).
-2. Add it under `mcp_servers` in `config.json`.
-3. Start `ollamarama`. Tools will be discovered automatically.
+1. Add your MCP server under `mcp_servers` in `config.json`. Each entry can be a URL or a `{ "command": ..., "args": [...] }` spec.
+2. Start `ollamarama`. Remote servers are connected to and command-based servers are launched automatically. Tools will be
+   discovered without extra steps.
 
 Security note: Tool calls can execute actions exposed by your MCP servers. Only connect to servers you trust and understand.
 

--- a/ollamarama/app.py
+++ b/ollamarama/app.py
@@ -43,10 +43,10 @@ class App:
         self.tools_enabled: bool = True
         self.mcp_client: FastMCPClient | None = None
         if self.config.mcp_servers:
-            urls = [url.strip() for url in self.config.mcp_servers.values() if url.strip()]
-            if urls:
+            servers = {k: v for k, v in self.config.mcp_servers.items() if v}
+            if servers:
                 try:
-                    self.mcp_client = FastMCPClient(urls)
+                    self.mcp_client = FastMCPClient(servers)
                     self._tools_schema = self.mcp_client.list_tools()
                 except Exception as e:
                     print_error(self.console, f"Failed to load tools from MCP server: {e}")

--- a/ollamarama/config.py
+++ b/ollamarama/config.py
@@ -28,7 +28,7 @@ class AppConfig:
     prompt: List[str]
     personality: str
     options: ModelOptions
-    mcp_servers: Dict[str, str] | None = None
+    mcp_servers: Dict[str, Any] | None = None
 
 
 def load_config(path: str | Path = "config.json") -> AppConfig:
@@ -73,7 +73,7 @@ def load_config(path: str | Path = "config.json") -> AppConfig:
         repeat_penalty=float(opts_raw.get("repeat_penalty", 1.0)),
     )
 
-    mcp_servers: Dict[str, str] | None = raw.get("mcp_servers")
+    mcp_servers: Dict[str, Any] | None = raw.get("mcp_servers")
 
     return AppConfig(
         api_base=api_base,

--- a/ollamarama/fastmcp_client.py
+++ b/ollamarama/fastmcp_client.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List
 
 from fastmcp import Client
 import mcp.types
 
 
 class FastMCPClient:
-    def __init__(self, urls: Sequence[str]) -> None:
-        if isinstance(urls, str):
-            urls = [urls]
-        self._clients = [Client(u) for u in urls]
+    def __init__(self, servers: Dict[str, Any]) -> None:
+        self._clients: List[Client] = []
+        for name, spec in servers.items():
+            if isinstance(spec, str):
+                target = spec.strip()
+                if not target:
+                    continue
+                self._clients.append(Client(target))
+            elif isinstance(spec, dict):
+                self._clients.append(Client({name: spec}))
         self._tool_clients: Dict[str, Client] = {}
 
     async def _list_tools_async(self) -> List[Dict[str, Any]]:

--- a/ollamarama/fastmcp_client.py
+++ b/ollamarama/fastmcp_client.py
@@ -16,9 +16,26 @@ class FastMCPClient:
                 target = spec.strip()
                 if not target:
                     continue
-                self._clients.append(Client(target))
+                if "://" not in target and " " in target:
+                    import shlex
+
+                    parts = shlex.split(target)
+                    cmd = parts[0]
+                    args = parts[1:]
+                    self._clients.append(Client({name: {"command": cmd, "args": args}}))
+                else:
+                    self._clients.append(Client(target))
             elif isinstance(spec, dict):
-                self._clients.append(Client({name: spec}))
+                cfg = dict(spec)
+                cmd = cfg.get("command")
+                if isinstance(cmd, str) and "args" not in cfg and " " in cmd:
+                    import shlex
+
+                    parts = shlex.split(cmd)
+                    cfg["command"] = parts[0]
+                    if len(parts) > 1:
+                        cfg["args"] = parts[1:]
+                self._clients.append(Client({name: cfg}))
         self._tool_clients: Dict[str, Client] = {}
 
     async def _list_tools_async(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- allow `mcp_servers` config entries to specify command-based servers
- connect to URL or command MCP servers in app startup
- document new `mcp_servers` format and examples

## Testing
- `python -m py_compile ollamarama/config.py ollamarama/fastmcp_client.py ollamarama/app.py`
- `python -m ollamarama --help`


------
https://chatgpt.com/codex/tasks/task_e_689b6aecbd748327847c8d19108a1158